### PR TITLE
Support for Gauge32 and closing transport thread used in SNMP to avoid java.lang.OutOfMemoryError: unable to create new native thread

### DIFF
--- a/src/main/java/org/wso2/carbon/esb/connector/SNMPConstants.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SNMPConstants.java
@@ -71,8 +71,8 @@ public class SNMPConstants {
 	public static final String COUNTER32 = "counter32";
 	// Constant for counter64.
 	public static final String COUNTER64 = "counter64";
-        // Constant for Gauge32.
-         public static final String GAUGE32 = "Gauge32";
+	// Constant for Gauge32.
+	public static final String GAUGE32 = "Gauge32";
 	// Constant for default retries.
 	public static final String DEFAULT_RETRIES = "5";
 	// Constant for default time out.

--- a/src/main/java/org/wso2/carbon/esb/connector/SNMPConstants.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SNMPConstants.java
@@ -71,6 +71,8 @@ public class SNMPConstants {
 	public static final String COUNTER32 = "counter32";
 	// Constant for counter64.
 	public static final String COUNTER64 = "counter64";
+        // Constant for Gauge32.
+         public static final String GAUGE32 = "Gauge32";
 	// Constant for default retries.
 	public static final String DEFAULT_RETRIES = "5";
 	// Constant for default time out.

--- a/src/main/java/org/wso2/carbon/esb/connector/SNMPSet.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SNMPSet.java
@@ -43,7 +43,7 @@ import java.io.IOException;
  */
 public class SNMPSet extends AbstractConnector implements Connector {
 	private Snmp snmp;
-	
+	TransportMapping transport;
 
 	/*
 	 * Connect method which is initiating the Set operation.
@@ -53,7 +53,6 @@ public class SNMPSet extends AbstractConnector implements Connector {
 	@Override
 	public void connect(MessageContext messageContext) throws ConnectException {
 		String updateOids = (String) messageContext.getProperty(SNMPConstants.UPDATE_OIDS);
-		TransportMapping transport;
 		try {
 			// Create TransportMapping
 			transport = new DefaultUdpTransportMapping();

--- a/src/main/java/org/wso2/carbon/esb/connector/SNMPSet.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SNMPSet.java
@@ -43,7 +43,7 @@ import java.io.IOException;
  */
 public class SNMPSet extends AbstractConnector implements Connector {
 	private Snmp snmp;
-	private TransportMapping transport;
+	
 
 	/*
 	 * Connect method which is initiating the Set operation.
@@ -53,6 +53,7 @@ public class SNMPSet extends AbstractConnector implements Connector {
 	@Override
 	public void connect(MessageContext messageContext) throws ConnectException {
 		String updateOids = (String) messageContext.getProperty(SNMPConstants.UPDATE_OIDS);
+		TransportMapping transport;
 		try {
 			// Create TransportMapping
 			transport = new DefaultUdpTransportMapping();

--- a/src/main/java/org/wso2/carbon/esb/connector/SNMPSet.java
+++ b/src/main/java/org/wso2/carbon/esb/connector/SNMPSet.java
@@ -43,6 +43,7 @@ import java.io.IOException;
  */
 public class SNMPSet extends AbstractConnector implements Connector {
 	private Snmp snmp;
+	private TransportMapping transport;
 
 	/*
 	 * Connect method which is initiating the Set operation.
@@ -54,7 +55,7 @@ public class SNMPSet extends AbstractConnector implements Connector {
 		String updateOids = (String) messageContext.getProperty(SNMPConstants.UPDATE_OIDS);
 		try {
 			// Create TransportMapping
-			TransportMapping transport = new DefaultUdpTransportMapping();
+			transport = new DefaultUdpTransportMapping();
 			// Create Snmp object for sending data to Agent
 			snmp = new Snmp(transport);
 			// Listens for response
@@ -99,6 +100,7 @@ public class SNMPSet extends AbstractConnector implements Connector {
 			handleException("Error while building the message: " + e.getMessage(), e, messageContext);
 		} finally {
 			try {
+				transport.close();
 				snmp.close();
 			} catch (IOException e) {
 				handleException("Error while closing the SNMP: " + e.getMessage(), e, messageContext);
@@ -138,6 +140,8 @@ public class SNMPSet extends AbstractConnector implements Connector {
 							pdu.add(new VariableBinding(new OID(oid), new Counter32(Integer.parseInt(UpdateValue))));
 						} else if ((type.equalsIgnoreCase(SNMPConstants.COUNTER64))) {
 							pdu.add(new VariableBinding(new OID(oid), new Counter64(Integer.parseInt(UpdateValue))));
+						} else if ((type.equalsIgnoreCase(SNMPConstants.GAUGE32))) {
+							pdu.add(new VariableBinding(new OID(oid), new Gauge32(Integer.parseInt(UpdateValue))));
 						} else {
 							log.warn("Given data Type is empty or wrong.");
 						}


### PR DESCRIPTION
## Purpose
> Support for Gauge32 and closing transport thread used in SNMP to avoid java.lang.OutOfMemoryError: unable to create new native thread



